### PR TITLE
Keep response header array if larger than 1

### DIFF
--- a/lib/rack/http_streaming_response.rb
+++ b/lib/rack/http_streaming_response.rb
@@ -17,8 +17,10 @@ module Rack
     def headers
       h = Utils::HeaderHash.new
       
-      response.each_header do |k, v|
-        h[k] = v
+      response.each_key do |k|
+        values = response.get_fields(k)
+        values = values.first if values.length == 1
+        h[k] = values
       end
       
       h

--- a/test/http_streaming_response_test.rb
+++ b/test/http_streaming_response_test.rb
@@ -4,7 +4,7 @@ require "rack/http_streaming_response"
 class HttpStreamingResponseTest < Test::Unit::TestCase
   
   def setup
-    host, req = "www.trix.pl", Net::HTTP::Get.new("/")
+    host, req = "www.example.com", Net::HTTP::Get.new("/")
     @response = Rack::HttpStreamingResponse.new(req, host)
   end
   

--- a/test/net_http_hacked_test.rb
+++ b/test/net_http_hacked_test.rb
@@ -5,18 +5,18 @@ class NetHttpHackedTest < Test::Unit::TestCase
   
   def test_net_http_hacked
     req = Net::HTTP::Get.new("/")
-    http = Net::HTTP.start("www.iana.org", "80")
+    http = Net::HTTP.start("www.example.com", "80")
     
     # Response code
     res = http.begin_request_hacked(req)
-    assert res.code == "200"
+    assert_equal "200", res.code
     
     # Headers
     headers = {}
     res.each_header { |k, v| headers[k] = v }
 
     assert headers.size > 0
-    assert headers["content-type"] == "text/html; charset=UTF-8"
+    assert_equal "text/html", headers["content-type"]
     assert !headers["date"].nil?
     
     # Body


### PR DESCRIPTION
I.e., if multiple set-cookie response headers are present, don't
collapse them. net/http default is to `.join(',')` them into a single
header, which we don't want.